### PR TITLE
Replace .bashrc with .profile

### DIFF
--- a/installation/Installing-PEcAn.md
+++ b/installation/Installing-PEcAn.md
@@ -29,8 +29,8 @@ The rest of the instructions assumes you have done the appropriate steps in each
 
 ```bash
 # point R to personal lib folder
-echo 'export R_LIBS_USER=${HOME}/R/library' >> ~/.bashrc
-source ~/.bashrc
+echo 'export R_LIBS_USER=${HOME}/R/library' >> ~/.profile
+source ~/.profile
 mkdir -p ${R_LIBS_USER}
 ```
 


### PR DESCRIPTION
`make` uses /bin/sh as its default shell rather than /bin/bash (for
POSIX compliance and broader compatibility), meaning that it doesn't
know about any variables set in `.bashrc`. `.profile` should be read by
all shells.